### PR TITLE
Math tool

### DIFF
--- a/client-data/board.html
+++ b/client-data/board.html
@@ -21,7 +21,7 @@
 	<link rel="alternate" hreflang="{{.}}" href="{{../boardUriComponent}}?lang={{.}}" />
 	{{/languages}}
 	<script src="../polyfill.min.js"></script>
-	<script type="text/javascript" id="MathJax-script" src="https://mj.dasmithmaths.com/mathjax/tex-svg-full.js"></script>
+	<script type="text/javascript" id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-svg-full.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
<!--
Thanks for taking the time to contribute to WBO !
Please use this field to describe the changes you made, and mention
the eventual issues this PR addresses: https://github.com/lovasoa/whitebophir/issues
Please also check the other existing pull requests: https://github.com/lovasoa/whitebophir/pulls
Please leave the license agreement below to grant us the rights to use your code.
-->
<sub>
By opening a pull request, I certify that I hold the intellectual property of the code I am submitting,
and I am granting the initial authors of WBO a perpetual, worldwide, non-exclusive, royalty-free, and irrevocable license to this code.
</sub>
Hi @dazsmith , this pull request makes just a couple of changes.

Firstly, it switches to a CDN for mathjax, which is the standard way to use it.

Secondly, it switches to a textarea for editing the math, and embeds the math in an align environment.  I don't think this should hurt for other use cases, although it does take a bit more screen real estate.  I also had to make the return character no longer end the math.  For my use cases, being able to type out more math (and expand the text entry box in both directions) will be very helpful.